### PR TITLE
ci: simplify and fix wrong pipenv commands

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -19,12 +19,8 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pipenv build
-          # Not using `--deploy` here. Updates should be handled by a bot.
-          pipenv install --dev
+        run: python3 -m pip install --upgrade build
       - name: Build package
-        # The `build` pkg is not installed in the virtualenv.
         run: python3 -m build
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pipenv build
-          # Not using `--deploy` here. Updates should be handled by a bot.
-          pipenv install --dev
+          pipenv sync --dev
       - name: Build package
         # The `build` pkg is not installed in the virtualenv.
         run: python3 -m build


### PR DESCRIPTION
Running `pipenv install` instead of `pipenv sync`, pipenv modifies Pipfile.lock every time a new version of a dependency is released. This makes setuptools_scm to detect a diff in the git repo and produces version like `0.0.11.dev...` instead of expected `0.0.11`. This now should be fixed.