### PR TITLE
fix: prevent colision with an existing `.env`

### DIFF
--- a/beanclerk/config.py
+++ b/beanclerk/config.py
@@ -91,7 +91,7 @@ class Config(pydantic_settings.BaseSettings):
 
     model_config = pydantic_settings.SettingsConfigDict(
         extra="forbid",
-        env_file=".env",
+        env_file=".beanclerk_env",
         env_prefix="beanclerk_",  # case-insensitive
     )
 


### PR DESCRIPTION
Other tools, like `pipenv`, may set `.env` file as well. Pydantic then refused this file for forbidden (i.e. unknown) keys. This is now fixed by expecting `.beanclerk_env` file.