### PR TITLE
Remove pinned uv version from GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-        with:
-          version: "0.5.5"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Let the setup-uv action use its default version instead of pinning to 0.5.5.